### PR TITLE
docs: Add missing /chooser

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -71,3 +71,4 @@ twingate_resource = tg.TwingateResource("test_resource",
 ```
 
 {{% /choosable %}}
+{{< /chooser >}}


### PR DESCRIPTION
The chooser is missing a `/chooser`,
which will break on some versions of Hugo.

Ref https://github.com/pulumi/registry/pull/2231